### PR TITLE
fix: relative_url breaking when docs markdown uses emoticons

### DIFF
--- a/_includes/js_files.html
+++ b/_includes/js_files.html
@@ -2,7 +2,7 @@
   var baseurl = '{{ site.baseurl }}'
 </script>
 <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
-<script src="{{ "/assets/js/bootstrap.min.js" | relative_url }} "></script>
-<script src="{{ "/assets/js/typeahead.bundle.min.js" | relative_url }} "></script>
+<script src="{{- "/assets/js/bootstrap.min.js" | relative_url -}} "></script>
+<script src="{{- "/assets/js/typeahead.bundle.min.js" | relative_url -}} "></script>
 
-<script src="{{ "/assets/js/main.js" | relative_url }} "></script>
+<script src="{{- "/assets/js/main.js" | relative_url -}} "></script>


### PR DESCRIPTION
Jekyll being weird and adding a whitespace when `relative_url` is used. Refer [this](https://stackoverflow.com/a/75410654) for fix.